### PR TITLE
feat: Add API to fetch customers by starting letter

### DIFF
--- a/bookstore/pom.xml
+++ b/bookstore/pom.xml
@@ -29,7 +29,6 @@
 
 	<properties>
 		<java.version>21</java.version>
-		<org.mapstruct.version>1.6.2</org.mapstruct.version>
 	</properties>
 
 	<dependencies>
@@ -83,16 +82,11 @@
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.6.0</version>
 		</dependency>
-		<dependency>
-			<groupId>org.mapstruct</groupId>
-			<artifactId>mapstruct</artifactId>
-			<version>${org.mapstruct.version}</version>
-		</dependency>
+
 	</dependencies>
 
 	<build>
 		<plugins>
-			<!-- Spring Boot Maven Plugin -->
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -105,8 +99,6 @@
 					</excludes>
 				</configuration>
 			</plugin>
-
-			<!-- Maven Javadoc Plugin -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
@@ -119,8 +111,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
-			<!-- Maven Compiler Plugin with Lombok and MapStruct in Annotation Processor Paths -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
@@ -129,15 +119,11 @@
 					<source>21</source>
 					<target>21</target>
 					<annotationProcessorPaths>
-						<path>
-							<groupId>org.mapstruct</groupId>
-							<artifactId>mapstruct-processor</artifactId>
-							<version>${org.mapstruct.version}</version>
-						</path>
+
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
-							<version>1.18.34</version> <!-- Adjust to your Lombok version if needed -->
+							<version>1.18.34</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/bookstore/src/main/java/com/bookstore/bookstore/controller/CustomerController.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/controller/CustomerController.java
@@ -1,0 +1,57 @@
+package com.bookstore.bookstore.controller;
+
+import com.bookstore.bookstore.dto.CustomerDto;
+import com.bookstore.bookstore.dto.ResponseDto;
+import com.bookstore.bookstore.entity.Customer;
+import com.bookstore.bookstore.service.CustomerService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("api/customer")
+public class CustomerController {
+
+    private final CustomerService customerService;
+
+    public CustomerController(
+            CustomerService customerService
+    ) {
+        this.customerService = customerService;
+    }
+
+
+    @Operation(
+            summary = "Retrieve customers with optional name filter",
+            description = "Retrieves a sorted list of customers, optionally filtering by first name starting letter."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Customers fetched successfully",
+                    content = @Content(schema = @Schema(implementation = ResponseDto.class)))
+    })
+    @GetMapping("/all-customers")
+    public ResponseEntity<ResponseDto<List<CustomerDto>>> getAllCustomers(
+            @RequestParam(value = "startsWith", required = false) String letter
+    ) {
+        log.info("Received request to fetch customers with filter letter: {}", letter);
+
+        List<CustomerDto> customers = customerService.getCustomersByFirstNameStartingWith(letter);
+        ResponseDto<List<CustomerDto>> response = new ResponseDto<>(customers, "Customers fetched successfully");
+
+        log.debug("Response content: {}", response);
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/bookstore/src/main/java/com/bookstore/bookstore/dto/CustomerDto.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/dto/CustomerDto.java
@@ -1,0 +1,30 @@
+package com.bookstore.bookstore.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomerDto {
+
+    @Schema(description = "Unique identifier of the customer", example = "1")
+    private Long id;
+
+    @Schema(description = "The first name of the customer", example = "John")
+    private String firstName;
+
+    @Schema(description = "The last name of the customer", example = "Doe")
+    private String lastName;
+
+    @Schema(description = "The address of the customer", example = "Via Argiro, 52, Bari")
+    private String address;
+
+    @Schema(description = "The email of the customer", example = "customer@example.com")
+    private String email;
+
+}

--- a/bookstore/src/main/java/com/bookstore/bookstore/mapper/CustomerMapper.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/mapper/CustomerMapper.java
@@ -1,0 +1,23 @@
+package com.bookstore.bookstore.mapper;
+
+import com.bookstore.bookstore.dto.CustomerDto;
+import com.bookstore.bookstore.entity.Customer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomerMapper {
+
+    public CustomerDto customerToCustomerDto(Customer customer) {
+
+        return CustomerDto.builder()
+                .id(customer.getId())
+                .firstName(customer.getFirstName())
+                .lastName(customer.getLastName())
+                .address(customer.getAddress())
+                .email(customer.getEmail())
+                .build();
+
+    }
+
+
+}

--- a/bookstore/src/main/java/com/bookstore/bookstore/repository/CustomerRepository.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/repository/CustomerRepository.java
@@ -1,0 +1,15 @@
+package com.bookstore.bookstore.repository;
+
+import com.bookstore.bookstore.entity.Customer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CustomerRepository extends JpaRepository<Customer, Long> {
+
+    @Query("SELECT c FROM Customer c WHERE :letter IS NULL OR LOWER(c.firstName) LIKE LOWER(CONCAT(:letter, '%')) ORDER BY c.firstName, c.lastName")
+    List<Customer> findCustomersByFirstNameStartingWith(@Param("letter") String letter);
+
+}

--- a/bookstore/src/main/java/com/bookstore/bookstore/service/CustomerService.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/service/CustomerService.java
@@ -1,0 +1,54 @@
+package com.bookstore.bookstore.service;
+
+import com.bookstore.bookstore.dto.CustomerDto;
+import com.bookstore.bookstore.entity.Customer;
+import com.bookstore.bookstore.mapper.CustomerMapper;
+import com.bookstore.bookstore.repository.CustomerRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional
+public class CustomerService {
+
+    private final CustomerRepository customerRepository;
+    private final CustomerMapper customerMapper;
+
+    public CustomerService(
+            CustomerRepository customerRepository,
+            CustomerMapper customerMapper
+    ) {
+        this.customerRepository = customerRepository;
+        this.customerMapper = customerMapper;
+    }
+
+    /**
+     * Retrieves a list of customers whose first names start with the specified letter.
+     * If no letter is provided, all customers are retrieved.
+     *
+     * @param letter an optional query parameter specifying the starting letter of the customer's first name
+     *               (case-insensitive). If not provided, all customers are returned.
+     * @return a ResponseEntity containing a ResponseDto with a list of CustomerDto objects and a success message.
+     *         The customers are sorted by first name and last name.
+     */
+    public List<CustomerDto> getCustomersByFirstNameStartingWith(String letter) {
+
+        log.info("Fetching customers with filter startsWith: {}", letter);
+
+        List<Customer> customers= customerRepository.findCustomersByFirstNameStartingWith(letter);
+
+        log.debug("Customers content: {}", customers);
+        log.debug("Fetched {} customer(s) with filter 'startsWith={}'. Customer details: {}", customers.size(), letter, customers);
+
+        return customers.stream()
+                .map(customerMapper::customerToCustomerDto)
+                .toList();
+
+    }
+
+}


### PR DESCRIPTION
- Added `findCustomersByFirstNameStartingWith` in `CustomerRepository` to filter customers by first name and sort by name.
- Updated `CustomerService` to map results to `CustomerDto`.
- Added `/all-customers` endpoint in `CustomerController` with optional `startsWith` parameter, returning customers in a `ResponseDto`.