### PR TITLE
feat: Add API to retrieve authors by first name starting letter

### DIFF
--- a/bookstore/src/main/java/com/bookstore/bookstore/controller/AuthorController.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/controller/AuthorController.java
@@ -1,0 +1,55 @@
+package com.bookstore.bookstore.controller;
+
+import com.bookstore.bookstore.dto.AuthorsDto;
+import com.bookstore.bookstore.dto.ResponseDto;
+import com.bookstore.bookstore.service.AuthorService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("api/author")
+public class AuthorController {
+
+    private final AuthorService authorService;
+
+    public AuthorController(
+            AuthorService authorService
+    ) {
+        this.authorService = authorService;
+    }
+
+    @Operation(
+            summary = "Retrieve authors with optional name filter",
+            description = "Retrieves a sorted list of authors, filtering by first name starting letter."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Authors fetched successfully",
+                    content = @Content(schema = @Schema(implementation = ResponseDto.class)))
+    })
+    @GetMapping("all-authors")
+    public ResponseEntity<ResponseDto<List<AuthorsDto>>> getAllAuthors(
+            @RequestParam("startsWith") String letter
+    ) {
+        log.info("Received request to fetch authors with filter letter: {}", letter);
+
+        List<AuthorsDto> authors = authorService.getAllAuthors(letter);
+
+        ResponseDto<List<AuthorsDto>> response = new ResponseDto<>(authors, "Authors fetched successfully");
+        log.debug("Response content: {}", response);
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/bookstore/src/main/java/com/bookstore/bookstore/dto/AuthorsDto.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/dto/AuthorsDto.java
@@ -1,0 +1,26 @@
+package com.bookstore.bookstore.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Data
+@Slf4j
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthorsDto {
+
+    @Schema(description = "The id of the author", example = "1")
+    private  Long id;
+
+    @Schema(description = "The first name of the author", example = "Dante")
+    private String firstName;
+
+    @Schema(description = "The last name of the author", example = "Alighieri")
+    private String lastName;
+
+}

--- a/bookstore/src/main/java/com/bookstore/bookstore/mapper/AuthorMapper.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/mapper/AuthorMapper.java
@@ -1,0 +1,18 @@
+package com.bookstore.bookstore.mapper;
+
+import com.bookstore.bookstore.dto.AuthorsDto;
+import com.bookstore.bookstore.entity.Author;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthorMapper {
+
+    public AuthorsDto authorToAuthorsDto(Author author) {
+        return AuthorsDto.builder()
+                .id(author.getId())
+                .firstName(author.getFirstName())
+                .lastName(author.getLastName())
+                .build();
+    }
+
+}

--- a/bookstore/src/main/java/com/bookstore/bookstore/service/AuthorService.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/service/AuthorService.java
@@ -1,0 +1,42 @@
+package com.bookstore.bookstore.service;
+
+import com.bookstore.bookstore.dto.AuthorsDto;
+import com.bookstore.bookstore.entity.Author;
+import com.bookstore.bookstore.mapper.AuthorMapper;
+import com.bookstore.bookstore.repository.AuthorRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional
+public class AuthorService {
+
+    private final AuthorRepository authorRepository;
+    private final AuthorMapper authorMapper;
+
+    public AuthorService(
+            AuthorRepository authorRepository,
+            AuthorMapper authorMapper
+    ) {
+        this.authorRepository = authorRepository;
+        this.authorMapper = authorMapper;
+    }
+
+    public List<AuthorsDto> getAllAuthors(String letter) {
+        log.info("Fetching authors with filter startsWith: {}", letter);
+
+        return authorRepository.findAll().stream()
+                .filter(author -> author.getFirstName().toLowerCase().startsWith(letter.toLowerCase()))
+                .sorted((a1, a2) -> a1.getFirstName().compareToIgnoreCase(a2.getFirstName()))
+                .map(authorMapper::authorToAuthorsDto)
+                .collect(Collectors.toList());
+    }
+
+
+
+}

--- a/bookstore/src/main/java/com/bookstore/bookstore/service/CustomerService.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/service/CustomerService.java
@@ -42,7 +42,6 @@ public class CustomerService {
 
         List<Customer> customers= customerRepository.findCustomersByFirstNameStartingWith(letter);
 
-        log.debug("Customers content: {}", customers);
         log.debug("Fetched {} customer(s) with filter 'startsWith={}'. Customer details: {}", customers.size(), letter, customers);
 
         return customers.stream()


### PR DESCRIPTION
- Implemented `AuthorController` with `/all-authors` endpoint to fetch authors filtered by first name starting letter.
- Added `AuthorService` with Java Streams for filtering and sorting authors by name.
- Created `AuthorsDto` to structure author response data.
- Introduced `AuthorMapper` for mapping `Author` entities to `AuthorsDto`.