### PR TITLE
feat: add API to retrieve books grouped by pubblication year

### DIFF
--- a/bookstore/src/main/java/com/bookstore/bookstore/controller/BookController.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/controller/BookController.java
@@ -26,6 +26,8 @@ import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 
 @Slf4j
@@ -210,6 +212,23 @@ public class BookController {
 
         String message = bookService.importBooks(file);
         return ResponseEntity.ok(new ResponseDto<>(null, message));
+    }
+
+    @Operation(
+            summary = "Retrieve books grouped by publication year",
+            description = "Fetches a list of books grouped by their year of publication. The response contains each publication year as a key, with values as the names of all books published in that year. " +
+                    "Books with fewer than 20 pages or with more than three words in the original name are excluded."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Books grouped by publication year retrieved successfully",
+                    content = @Content(schema = @Schema(implementation = ResponseDto.class)))
+    })
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    @GetMapping("/books-by-year")
+    public ResponseEntity<ResponseDto<Map<Integer, List<String>>>> getBooksByPublicationYear() {
+        Map<Integer, List<String>> booksByYear = bookService.getBooksByPublicationYear();
+        ResponseDto<Map<Integer, List<String>>> response = new ResponseDto<>(booksByYear, "Books grouped by publication year retrieved successfully.");
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/bookstore/src/main/java/com/bookstore/bookstore/service/BookService.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/service/BookService.java
@@ -22,10 +22,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 
 @Transactional
@@ -252,6 +250,26 @@ public class BookService {
 
         failedRecords.forEach(record -> log.error("Failed to import record: {}", record));
         return String.format("Imported %d books successfully. %d rows failed.", successCount, failedRecords.size());
+    }
+
+    /**
+     * Retrieves a map of books grouped by their publication year.
+     * <p>
+     * This method fetches all books from the repository, filters out any books
+     * with fewer than 20 pages or with more than three words in their original name,
+     * and then groups the remaining books by their publication year.
+     * </p>
+     *
+     * @return a map where each key is a publication year, and each value is a list of names of books published that year.
+     */
+    public Map<Integer, List<String>> getBooksByPublicationYear() {
+        return bookRepository.findAll().stream()
+                .filter(book -> book.getTotalPageCount() >= 20)
+                .filter(book -> book.getOriginalName().split("\\s+").length <= 3)
+                .collect(Collectors.groupingBy(
+                        book -> book.getPublicationDate().getYear(),
+                        Collectors.mapping(Book::getName, Collectors.toList())
+                ));
     }
 
 }


### PR DESCRIPTION
- Implemented `getBooksByPublicationYear` method in `BookService` to fetch books grouped by publication year
- Filtered out books with fewer than 20 pages or with more than three words in the original name
- Added controller endpoint to expose API with no input parameters, returning publication year as key and book names as values