### PR TITLE
feat: Add external Cat Facts API integration

### DIFF
--- a/bookstore/src/main/java/com/bookstore/bookstore/config/AppConfig.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/config/AppConfig.java
@@ -2,8 +2,10 @@ package com.bookstore.bookstore.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class AppConfig {
@@ -11,6 +13,14 @@ public class AppConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(10000);
+        factory.setReadTimeout(10000);
+        return new RestTemplate(factory);
     }
 }
 

--- a/bookstore/src/main/java/com/bookstore/bookstore/controller/CatFactController.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/controller/CatFactController.java
@@ -1,0 +1,49 @@
+package com.bookstore.bookstore.controller;
+
+import com.bookstore.bookstore.dto.CatFactResponseDto;
+import com.bookstore.bookstore.dto.ResponseDto;
+import com.bookstore.bookstore.exception.CatFactException;
+import com.bookstore.bookstore.service.CatFactService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.ResourceAccessException;
+
+@RestController
+@RequestMapping("/api/cat")
+public class CatFactController {
+
+    private final CatFactService catFactService;
+
+    @Autowired
+    public CatFactController(CatFactService catFactService) {
+        this.catFactService = catFactService;
+    }
+
+    @Operation(
+            summary = "Retrieve a random cat fact",
+            description = "Fetches a random fact about cats from an external API. " +
+                    "If the external service is unavailable or times out, a fallback message will be returned."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Cat fact retrieved successfully",
+                    content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "No facts available",
+                    content = @Content(schema = @Schema(implementation = CatFactException.class))),
+            @ApiResponse(responseCode = "503", description = "Cat fact service unavailable",
+                    content = @Content(schema = @Schema(implementation = ResourceAccessException.class)))
+    })
+    @GetMapping("/get-cat-fact")
+    public ResponseEntity<ResponseDto<CatFactResponseDto>> getCatFact() {
+        CatFactResponseDto catFact = catFactService.getCatFact();
+        ResponseDto<CatFactResponseDto> response = new ResponseDto<>(catFact, "Cat fact retrieved successfully");
+        return ResponseEntity.ok(response);
+    }
+}

--- a/bookstore/src/main/java/com/bookstore/bookstore/dto/CatFactResponseDto.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/dto/CatFactResponseDto.java
@@ -1,0 +1,27 @@
+package com.bookstore.bookstore.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Data Transfer Object for holding a cat fact retrieved from an external API.
+ * <p>
+ * This DTO contains a single field, {@code catFact}, which stores the cat fact
+ * to be returned to the user.
+ * </p>
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CatFactResponseDto {
+
+    @JsonProperty("fact")
+    @Schema(description = "The cat fact to return to the user")
+    private  String catFact;
+
+}

--- a/bookstore/src/main/java/com/bookstore/bookstore/exception/CatFactException.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/exception/CatFactException.java
@@ -1,0 +1,8 @@
+package com.bookstore.bookstore.exception;
+
+public class CatFactException extends RuntimeException {
+    public CatFactException(String message) {
+        super(message);
+    }
+}
+

--- a/bookstore/src/main/java/com/bookstore/bookstore/service/CatFactService.java
+++ b/bookstore/src/main/java/com/bookstore/bookstore/service/CatFactService.java
@@ -1,0 +1,43 @@
+package com.bookstore.bookstore.service;
+
+import com.bookstore.bookstore.dto.CatFactResponseDto;
+import com.bookstore.bookstore.exception.CatFactException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class CatFactService {
+
+    private final RestTemplate restTemplate;
+
+    @Autowired
+    public CatFactService(
+            RestTemplate restTemplate
+    ) {
+        this.restTemplate = restTemplate;
+    }
+
+    /**
+     * Retrieves a random cat fact from an external API.
+     * <p>
+     * This method calls the Cat Facts API to fetch a random fact about cats.
+     * If the response from the external API is null or does not contain a valid cat fact,
+     * a {@link CatFactException} is thrown with the message "No fact available."
+     * </p>
+     *
+     * @return a {@link CatFactResponseDto} containing the retrieved cat fact.
+     * @throws CatFactException if the external API responds without providing a valid fact.
+     */
+    public CatFactResponseDto getCatFact() {
+        String url = "https://catfact.ninja/fact";
+        CatFactResponseDto response = restTemplate.getForObject(url, CatFactResponseDto.class);
+
+        if (response == null || response.getCatFact() == null) {
+            throw new CatFactException("No fact available.");
+        }
+        return response;
+    }
+
+}
+


### PR DESCRIPTION
- Created `CatFactController` to expose API endpoint for retrieving cat facts
- Added `CatFactService` to handle API requests to the external Cat Facts API
- Added `CatFactResponseDto` for response mapping from the external API
- Added `CatFactException` to handle missing or invalid cat facts
- Updated `GlobalExceptionHandler` to handle `CatFactException` and `ResourceAccessException` with appropriate fallback responses
- Configured `RestTemplate` in `AppConfig` with custom timeout settings for external requests